### PR TITLE
Mapping json in memory instead of disk

### DIFF
--- a/src/somef/export/turtle_export.py
+++ b/src/somef/export/turtle_export.py
@@ -171,14 +171,14 @@ class DataGraph:
             temp_json_file_path = temp_json_file.name
             
         data_file = temp_json_file_path
-
+        
         # Modifica la configuración para usar el contenido JSON directamente
         config = constants.MAPPING_CONFIG
         
         config = config.replace("$PATH", mapping_path).replace("$DATA", data_file)
         
         result_graph = morph_kgc.materialize(config)
-        
+        os.remove(temp_json_file_path)
         # option sending dictionary. In revision because just works with rml instead (not with main-source) of yml
         # result_graph = morph_kgc.materialize(config, data)
         

--- a/src/somef/utils/constants.py
+++ b/src/somef/utils/constants.py
@@ -222,9 +222,15 @@ MAPPING_CONFIG = """
                     file_path: $DATA
                  """
 
+MAPPING_CONFIG_DICT = """
+                    [DataSource1]
+                    mappings: $PATH
+                 """
+                 
 mapping_path = str(Path(__file__).parent.parent) + os.path.sep + "mapping" + os.path.sep + "yarrrml.yml"
+ 
+# mapping_path = str(Path(__file__).parent.parent) + os.path.sep + "mapping" + os.path.sep + "rml.ttl"
 
-#mapping_path = str(Path(__file__).parent.parent) + os.path.sep + "mapping" + os.path.sep + "rml.ttl"
 AUX_RELEASES_IDS = "releases_ids"
 
 class RepositoryType(Enum):

--- a/src/somef/utils/constants.py
+++ b/src/somef/utils/constants.py
@@ -226,7 +226,8 @@ MAPPING_CONFIG_DICT = """
                     [DataSource1]
                     mappings: $PATH
                  """
-                 
+       
+# YML by default          
 mapping_path = str(Path(__file__).parent.parent) + os.path.sep + "mapping" + os.path.sep + "yarrrml.yml"
  
 # mapping_path = str(Path(__file__).parent.parent) + os.path.sep + "mapping" + os.path.sep + "rml.ttl"


### PR DESCRIPTION
file default yml in constants. Json save in memory and is not necessary to create a file in disk. But we would like to send de json directly as parameter in apply_mapping