### PR TITLE
Fix #753 for requirements.txt and pyroject.toml

### DIFF
--- a/src/somef/parser/python_parser.py
+++ b/src/somef/parser/python_parser.py
@@ -313,7 +313,8 @@ def parse_requirements_txt(file_path, metadata_result: Result, source):
     metadata_result: Updated metadata result object
     """
     try:
-        if Path(file_path).name.lower() in ["requirements.txt", "requirment.txt"]:
+        if Path(file_path).name.lower() in ["requirements.txt", "requirement.txt"]:
+
             
             with open(file_path, "r", encoding="utf-8") as f:
                 for line in f:

--- a/src/somef/parser/python_parser.py
+++ b/src/somef/parser/python_parser.py
@@ -159,7 +159,26 @@ def parse_pyproject_toml(file_path, metadata_result: Result, source):
                             constants.TECHNIQUE_CODE_CONFIG_PARSER,
                             source
                         )
-                
+                        
+                # This is for detecting the "requires" section in a pyrpoject.toml file      
+                if "build-system" in data and "requires" in data["build-system"]:
+                    build_requires = data["build-system"]["requires"]
+                    if isinstance(build_requires, list):
+                        for req in build_requires:
+                            name, version = parse_dependency(req)
+                            if name:
+                                metadata_result.add_result(
+                                    constants.CAT_REQUIREMENTS,
+                                    {
+                                        "value": req,
+                                        "name": name,
+                                        "version": version,
+                                        "type": constants.SOFTWARE_APPLICATION
+                                    },
+                                    1,
+                                    constants.TECHNIQUE_CODE_CONFIG_PARSER,
+                                    source
+                                )
                 
                 urls = project.get("urls", {})
                 if not urls and "tool" in data and "poetry" in data["tool"]:
@@ -280,8 +299,46 @@ def parse_pyproject_toml(file_path, metadata_result: Result, source):
         logging.error(f"Error parsing pyproject.toml from {file_path}: {str(e)}")
 
     return metadata_result    
-    
-################################ setup.py #########################################
+
+def parse_requirements_txt(file_path, metadata_result: Result, source):
+    """
+    Parameters
+    ----------
+    file_path: path to the requirements.txt file being analyzed
+    metadata_result: Metadata object dictionary
+    source: source of the package file (URL)
+
+    Returns
+    -------
+    metadata_result: Updated metadata result object
+    """
+    try:
+        if Path(file_path).name.lower() in ["requirements.txt", "requirment.txt"]:
+            
+            with open(file_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith('#'):
+                        continue
+                    name, version = parse_dependency(line)
+                    if name:
+                        metadata_result.add_result(
+                            constants.CAT_REQUIREMENTS,
+                            {
+                                "value": line,
+                                "name": name,
+                                "version": version,
+                                "type": constants.SOFTWARE_APPLICATION
+                            },
+                            1,
+                            constants.TECHNIQUE_CODE_CONFIG_PARSER,
+                            source
+                        )
+    except Exception as e:
+        logging.error(f"Error parsing requirements.txt from {file_path}: {str(e)}")
+
+    return metadata_result
+
 def parse_setup_py(file_path, metadata_result: Result, source):
     """
 

--- a/src/somef/process_files.py
+++ b/src/somef/process_files.py
@@ -12,6 +12,7 @@ from .parser.pom_xml_parser import parse_pom_file
 from .parser.package_json_parser import parse_package_json_file
 from .parser.python_parser import parse_pyproject_toml
 from .parser.python_parser import parse_setup_py
+from.parser.python_parser import parse_requirements_txt
 from chardet import detect
 
 domain_gitlab = ''
@@ -175,9 +176,10 @@ def process_repository_files(repo_dir, metadata_result: Result, repo_type, owner
                                                    )
                 if filename.upper() == constants.CODEOWNERS_FILE:
                     codeowners_json = parse_codeowners_structured(dir_path,filename)
+
                     # TO DO: Code owners not fully implemented yet
                 if filename.lower() == "pom.xml" or filename.lower() == "package.json" or \
-                    filename.lower() == "pyproject.toml" or filename.lower() == "setup.py":
+                    filename.lower() == "pyproject.toml" or filename.lower() == "setup.py" or filename.lower() == "requirements.txt":
                         build_file_url = get_file_link(repo_type, file_path, owner, repo_name, repo_default_branch,
                                                        repo_dir,
                                                        repo_relative_path, filename)
@@ -198,6 +200,8 @@ def process_repository_files(repo_dir, metadata_result: Result, repo_type, owner
                             metadata_result = parse_pyproject_toml(os.path.join(dir_path, filename), metadata_result, build_file_url)
                         if filename.lower() == "setup.py":
                             metadata_result = parse_setup_py(os.path.join(dir_path, filename), metadata_result, build_file_url)
+                        if filename.lower() == "requirements.txt":
+                            metadata_result = parse_requirements_txt(os.path.join(dir_path, filename), metadata_result, build_file_url)
 
                 # if repo_type == constants.RepositoryType.GITLAB: 
                 if filename.endswith(".yml"):

--- a/src/somef/test/test_data/repositories/inspect4py/docs/requirements.txt
+++ b/src/somef/test/test_data/repositories/inspect4py/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material

--- a/src/somef/test/test_data/repositories/inspect4py/pyproject.toml
+++ b/src/somef/test/test_data/repositories/inspect4py/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = [
+    "bs4==0.0.1",
+    "docstring_parser==0.7",
+    "astor",
+    "graphviz",
+    "click",
+    "pigar",
+    "setuptools==54.2.0",
+    "json2html",
+    "configparser",
+    "tree-sitter",
+    "requests"
+]
+build-backend = "setuptools.build_meta"

--- a/src/somef/test/test_data/repositories/inspect4py/requirements.txt
+++ b/src/somef/test/test_data/repositories/inspect4py/requirements.txt
@@ -1,0 +1,12 @@
+docstring_parser==0.7
+astor
+graphviz
+click
+pigar
+setuptools==54.2.0
+json2html
+configparser
+bigcode_astgen
+GitPython
+tree-sitter
+requests

--- a/src/somef/test/test_data/repositories/inspect4py/setup.py
+++ b/src/somef/test/test_data/repositories/inspect4py/setup.py
@@ -1,0 +1,51 @@
+import os
+from distutils.core import setup
+from setuptools import find_packages  # type: ignore
+
+
+def read(fname):
+    print("installing inspect4py")
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+with open('requirements.txt', 'r') as f:
+    install_requires = list()
+    dependency_links = list()
+    for line in f:
+        re = line.strip()
+        if re:
+            if re.startswith('git+') or re.startswith('svn+') or re.startswith('hg+'):
+                dependency_links.append(re)
+            else:
+                install_requires.append(re)
+
+packages = find_packages()
+
+version = {}
+with open("inspect4py/__init__.py") as fp:
+    exec(fp.read(), version)
+
+setup(
+    name='inspect4py',
+    version=version["__version__"],
+    packages=packages,
+    url='https://github.com/SoftwareUnderstanding/inspect4py',
+    license='BSD-3-Clause',
+    author='Rosa Filgueira and Daniel Garijo',
+    description='Static code analysis package for Python repositories',
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    include_package_data=True,
+    install_requires=install_requires,
+    dependency_links=dependency_links,
+    python_requires=">=3.6",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python",
+    ],
+    entry_points={
+        'console_scripts': [
+            'inspect4py = inspect4py.cli:main',
+        ],
+    }
+)


### PR DESCRIPTION
Now it can detect requirements.txt and parse the dependencies, and fixed the problem where we don't parse the requirements from pyproject.toml in [inspect4py](https://github.com/SoftwareUnderstanding/inspect4py/blob/main/pyproject.toml)