### PR TITLE
Adds parsing of R dependencies from DESCRIPTION files

### DIFF
--- a/src/somef/parser/description_parser.py
+++ b/src/somef/parser/description_parser.py
@@ -197,7 +197,6 @@ def parse_description_file(file_path, metadata_result: Result, source):
 
                 for field in ('Depends', 'Imports'):
                     section_match = re.search(r'^' + field + r':\s*(.*(?:\n[ \t]+.*)*)', content, re.MULTILINE)
-                    import pdb; pdb.set_trace()
                     if section_match:
                         section_text = section_match.group(1)
                         dependencies = re.findall(r'([A-Za-z][A-Za-z0-9.]*)\s*(?:\(([^)]*)\))?', section_text)

--- a/src/somef/test/test_description_parser.py
+++ b/src/somef/test/test_description_parser.py
@@ -98,6 +98,19 @@ class TestDescriptionParser(unittest.TestCase):
         self.assertTrue(len(issue_tracker_results) > 0, "No issue tracker found")
         self.assertEqual(issue_tracker_results[0]["result"]["value"], "https://github.com/tidyverse/ggplot2/issues")
 
+        requirements_results = metadata_result.results.get(constants.CAT_REQUIREMENTS, [])
+        self.assertTrue(len(requirements_results) > 0, "No dependencies found")
+
+        found_scales = False
+        for req_result in requirements_results:
+            dependency = req_result["result"]
+            if dependency.get("name") == "scales":
+                found_scales = True
+                self.assertEqual(dependency.get("version"), ">= 1.4.0")
+                self.assertEqual(dependency.get("value"), "scales (>= 1.4.0)")
+                break
+        self.assertTrue(found_scales, "scales dependency not found")
+
         
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR only adds parsing of dependencies from DESCRIPTION files and adapts the corresponding test. 

I adapted both tests, as the two DESCRIPTION files in the test data conveniently use two different formats of listing the requirements (one-per-line vs multi-line).

Is there anything else that needs to be adapted (e.g., I have seen that parsers are documented in `docs`)?