### PR TITLE
Added extra case for programming language version extraction codemeta.json

### DIFF
--- a/src/somef/parser/codemeta_parser.py
+++ b/src/somef/parser/codemeta_parser.py
@@ -759,6 +759,38 @@ def parse_codemeta_json_file(file_path, metadata_result: Result, source):
                             source
                         )
 
+            if "runtimePlatform" in data:
+                runtime_platforms = data["runtimePlatform"]
+                if isinstance(runtime_platforms, str):
+                    runtime_platforms = [runtime_platforms]
+                if isinstance(runtime_platforms, list):
+                    for rp in runtime_platforms:
+                        if isinstance(rp, str):
+                            metadata_result.add_result(
+                                constants.CAT_RUNTIME_PLATFORM,
+                                {
+                                    "value": rp,
+                                    "type": constants.STRING
+                                },
+                                1,
+                                constants.TECHNIQUE_CODE_CONFIG_PARSER,
+                                source
+                            )
+                            match = re.search(r'^([a-zA-Z0-9_\-\.]+)\s+version\s+([0-9][0-9a-zA-Z\.\-]*)', rp, re.IGNORECASE)
+                            if match:
+                                metadata_result.add_result(
+                                    constants.CAT_PROGRAMMING_LANGUAGES,
+                                    {
+                                        "name": match.group(1),
+                                        "value": match.group(1),
+                                        "version": match.group(2),
+                                        "type": constants.LANGUAGE
+                                    },
+                                    1,
+                                    constants.TECHNIQUE_CODE_CONFIG_PARSER,
+                                    source
+                                )
+
     except Exception as e:
         logging.error(f"Error parsing codemeta JSON file {file_path}: {str(e)}")
 

--- a/src/somef/process_files.py
+++ b/src/somef/process_files.py
@@ -294,7 +294,6 @@ def process_repository_files(repo_dir, metadata_result: Result, repo_type, owner
                                                },
                                                1,
                                                constants.TECHNIQUE_FILE_EXPLORATION, build_file_url)
-                        logging.info(f"############### (NEW UPDATE) Processing package file: {filename} ############### ")
                         if filename.lower() == "pom.xml":
                             metadata_result = parse_pom_file(os.path.join(dir_path, filename), metadata_result, build_file_url)
                         if filename.lower() == "package.json":


### PR DESCRIPTION
SoMEF does not extract programming language in the case of this format "runtimePlatform":

```
{
...
  "programmingLanguage": {
    "@type": "ComputerLanguage",
    "name": "R",
    "url": "https://r-project.org"
  },
  "runtimePlatform": "R version 4.4.0 (2024-04-24 ucrt)", 
...
 }
```